### PR TITLE
refactor: replace Math.log with bit operations for node bits calculation

### DIFF
--- a/src/main/java/com/github/f4b6a3/tsid/TsidFactory.java
+++ b/src/main/java/com/github/f4b6a3/tsid/TsidFactory.java
@@ -487,7 +487,7 @@ public final class TsidFactory {
 			if (this.nodeBits == null) {
 				if (Settings.getNodeCount() != null) {
 					// use property or variable
-					this.nodeBits = (int) Math.ceil(Math.log(Settings.getNodeCount()) / Math.log(2));
+					this.nodeBits = Integer.SIZE - Integer.numberOfLeadingZeros(Settings.getNodeCount() - 1);
 				} else {
 					// use default bit length: 10 bits
 					this.nodeBits = TsidFactory.NODE_BITS_1024;


### PR DESCRIPTION
## Summary

Refactor the node-bits calculation in TsidFactory.Builder.getNodeBits() by replacing a floating-point logarithm expression with an equivalent integer bit operation.
This change improves clarity and mathematical robustness, and avoids unnecessary floating-point operations in a code path that runs only during factory initialization.

### Why a Refactor?

Although the bit-operation approach is theoretically faster, this logic runs only once during startup, so the main motivation is not performance.

Instead, the change aims to:
- remove floating-point precision concerns,
- express the intent (compute required bit width) more directly, and
- align with the library’s existing bit-oriented style.

### Testing

The existing testWithNodeCount() test already covers all valid nodeBits cases (0–20), and the new implementation produces identical results, ensuring full backward compatibility.

---

Thank you for maintaining this excellent library!
Happy to revise anything if needed.