### PR TITLE
module descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See more options in [maven.org](https://search.maven.org/artifact/com.github.f4b
 
 Module and bundle names are the same as the root package name.
 
-*   JPMS module name: `com.github.f4b6a3.tsid`
+*   Java module name: `com.github.f4b6a3.tsid`
 *   OSGi symbolic name: `com.github.f4b6a3.tsid`
 
 ### TSID as Long

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,12 @@
 	</developers>
 
 	<properties>
-		<jdk.version>8</jdk.version>
+		<!-- source and target bytecode -->
+		<java.version>8</java.version>
+		<!-- minimum JDK used to compile to java.version -->
+		<jdk.version>9</jdk.version>
 		<package.name>com.github.f4b6a3.tsid</package.name>
-		<maven.compiler.source>${jdk.version}</maven.compiler.source>
-		<maven.compiler.target>${jdk.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -60,6 +62,26 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.6.3</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>${jdk.version}</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,41 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.15.0</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.moditect</groupId>
+				<artifactId>moditect-maven-plugin</artifactId>
+				<version>1.3.0.Final</version>
+				<executions>
+					<execution>
+						<id>add-module-infos</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-module-info</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<module>
+						<moduleInfo>
+							<name>${package.name}</name>
+							<exports>
+								${package.name};
+							</exports>
+						</moduleInfo>
+					</module>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.2.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
-							<!-- Java Modularity -->
-							<Automatic-Module-Name>${package.name}</Automatic-Module-Name>
 							<!-- OSGi Modularity -->
 							<Bundle-ManifestVersion>2</Bundle-ManifestVersion>
 							<Bundle-Name>${project.artifactId}</Bundle-Name>


### PR DESCRIPTION
- **[#38] rename 'JPMS' to 'Java module'.**
- **[#38] require a JDK 9 for building, creating Java 8 bytecode**
- **[#38] use moditect to create a module descriptor**

Fixes #38 


This commit will requirer the project to be compiled with Java 9 or a more recent version, but will keep compatibility to Java 8. Java 8 ignores module-info.class.

Options:

1. move `module-info.class` to a MultiRelease-Jar-Location (don't know if there are any benefits)
2. remove Moditect and require Java 9 or even 11 to compile this project (keeping Java 8 target runtime) -- **not recommended**, see below
3. Like 2, but raise Bytecode Level to 11 (breaking change) -- see below
4. Use [a two-step compilation instead of using moditect](https://maven.apache.org/plugins/maven-compiler-plugin-4.x/examples/module-info.html). Slower and more error-prone, still requires Java 9+. Not recommended.


**Removing Moditect**

Moditect is a great solution for projects like this, because it allows defining the module name in `pom.xml`.
If we switch to `module-info.java`, PRs might create conflicts more easily.